### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Lorem Ipsum: The Next Generation
+# Lorem Ipsum: The Next Generation
 
 ![riker](https://cloud.githubusercontent.com/assets/1502483/9260573/62ab0e12-41bd-11e5-887f-664af664f421.gif)
 
@@ -12,15 +12,15 @@ This project was inspired by the many other "lorem ipsum" type generators out th
 
 I found a site, http://antoa.com/tng/, which contains the scripts of every episode of Star Trek: The Next Generation. I scraped the site then parsed out all Riker's lines. After a little bit of cleaning up, I created a large object full of every line he's ever spoken in TNG. I saved that to a pickle for quick loading, and wrote **rikeripsum.py** to generate random sentences. 
 
-###TODO
+### TODO
 - Ability to generate random words. 
 - Ability to select which character you'd like to pull lines from (this is started). 
 - Perhaps a way to construct truly random sentences using a sampling of words from the dialog.
 
-###Try it out
-#####Live sample available here: http://ben174.github.io/rikeripsum/
+### Try it out
+##### Live sample available here: http://ben174.github.io/rikeripsum/
 
-##Usage
+## Usage
 
     from rikeripsum import rikeripsum
     rikeripsum.generate_paragraph()


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
